### PR TITLE
starRoll fix

### DIFF
--- a/Chapter 06/checkpoint - 6b/Pierre The Penguin/GameScene.swift
+++ b/Chapter 06/checkpoint - 6b/Pierre The Penguin/GameScene.swift
@@ -92,27 +92,24 @@ class GameScene: SKScene {
             encounterManager.placeNextEncounter(
                 currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
-        }
-        
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)
-                > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 +
-                    CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x:
-                    nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
+            
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
             }
         }
-
-
 
     }
     

--- a/Chapter 07/checkpoint - 7a/Pierre The Penguin/GameScene.swift
+++ b/Chapter 07/checkpoint - 7a/Pierre The Penguin/GameScene.swift
@@ -102,27 +102,24 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             encounterManager.placeNextEncounter(
                 currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
-        }
-        
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)
-                > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 +
-                    CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x:
-                    nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
+            
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
             }
         }
-
-
 
     }
     

--- a/Chapter 07/checkpoint - 7b/Pierre The Penguin/GameScene.swift
+++ b/Chapter 07/checkpoint - 7b/Pierre The Penguin/GameScene.swift
@@ -103,27 +103,25 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             encounterManager.placeNextEncounter(
                 currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
-        }
-        
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        //let starRoll = 0
-
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)  > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 + CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
+            
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
             }
         }
-
-
-
+        
     }
     
     func didBegin(_ contact: SKPhysicsContact) {

--- a/Chapter 08/checkpoint - 8a/Pierre The Penguin/GameScene.swift
+++ b/Chapter 08/checkpoint - 8a/Pierre The Penguin/GameScene.swift
@@ -130,22 +130,22 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             encounterManager.placeNextEncounter(
                 currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
-        }
-        
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        //let starRoll = 0
-
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)  > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 + CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
+            
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
             }
         }
 

--- a/Chapter 08/checkpoint - 8b/Pierre The Penguin/GameScene.swift
+++ b/Chapter 08/checkpoint - 8b/Pierre The Penguin/GameScene.swift
@@ -145,23 +145,24 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             encounterManager.placeNextEncounter(
                 currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
-        }
-        
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        //let starRoll = 0
-
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)  > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 + CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
+            
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
             }
+            
         }
 
         // Position the backgrounds:

--- a/Chapter 09/checkpoint - 9a/Pierre The Penguin/GameScene.swift
+++ b/Chapter 09/checkpoint - 9a/Pierre The Penguin/GameScene.swift
@@ -151,22 +151,23 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             encounterManager.placeNextEncounter(
                 currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
-        }
-        
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        //let starRoll = 0
-
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)  > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 + CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
+            
+            
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
             }
         }
 

--- a/Chapter 09/checkpoint - 9b/Pierre The Penguin/GameScene.swift
+++ b/Chapter 09/checkpoint - 9b/Pierre The Penguin/GameScene.swift
@@ -155,23 +155,24 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             encounterManager.placeNextEncounter(
                 currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
-        }
         
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        //let starRoll = 0
-
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)  > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 + CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
             }
+        
         }
 
         // Position the backgrounds:

--- a/Chapter 10/checkpoint - 10a/Pierre The Penguin/GameScene.swift
+++ b/Chapter 10/checkpoint - 10a/Pierre The Penguin/GameScene.swift
@@ -159,25 +159,26 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             encounterManager.placeNextEncounter(
                 currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
+        
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
+            }
+            
         }
         
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        //let starRoll = 0
-
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)  > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 + CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
-            }
-        }
-
         // Position the backgrounds:
         for background in self.backgrounds {
             background.updatePosition(playerProgress:

--- a/Chapter 10/checkpoint - 10b/Pierre The Penguin/GameScene.swift
+++ b/Chapter 10/checkpoint - 10b/Pierre The Penguin/GameScene.swift
@@ -164,35 +164,35 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         
         // Check to see if we should set a new encounter:
         if player.position.x > nextEncounterSpawnPosition {
-            encounterManager.placeNextEncounter(
-                currentXPos: nextEncounterSpawnPosition)
+            encounterManager.placeNextEncounter( currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
-        }
-        
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        //let starRoll = 0
-
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)  > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 + CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
+            
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
             }
+            
+            if starRoll == 1 {
+                // Position the heart crate after this encounter:
+                heartCrate.reset()
+                heartCrate.position = CGPoint(x:
+                    nextEncounterSpawnPosition - 600, y: 270)
+            }
+            
         }
         
-        if starRoll == 1 {
-            // Position the heart crate after this encounter:
-            heartCrate.reset()
-            heartCrate.position = CGPoint(x:
-                nextEncounterSpawnPosition - 600, y: 270)
-        }
-
 
         // Position the backgrounds:
         for background in self.backgrounds {


### PR DESCRIPTION
This update means that the code relating to spawning a star, or heart crate is ONLY run if we set a new encounter.  

Previously, EVERY time didSimulatephysics() fires this code is run.  Hence, the 10% chance assumption is not functioning properly.