### PR TITLE
Fixes: starRoll, Complete die() before HUD appears, sliderKnob

### DIFF
--- a/Chapter 06/checkpoint - 6b/Pierre The Penguin/GameScene.swift
+++ b/Chapter 06/checkpoint - 6b/Pierre The Penguin/GameScene.swift
@@ -92,27 +92,24 @@ class GameScene: SKScene {
             encounterManager.placeNextEncounter(
                 currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
-        }
-        
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)
-                > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 +
-                    CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x:
-                    nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
+            
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
             }
         }
-
-
 
     }
     

--- a/Chapter 07/checkpoint - 7a/Pierre The Penguin/GameScene.swift
+++ b/Chapter 07/checkpoint - 7a/Pierre The Penguin/GameScene.swift
@@ -102,27 +102,24 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             encounterManager.placeNextEncounter(
                 currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
-        }
-        
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)
-                > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 +
-                    CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x:
-                    nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
+            
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
             }
         }
-
-
 
     }
     

--- a/Chapter 07/checkpoint - 7b/Pierre The Penguin/GameScene.swift
+++ b/Chapter 07/checkpoint - 7b/Pierre The Penguin/GameScene.swift
@@ -103,27 +103,25 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             encounterManager.placeNextEncounter(
                 currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
-        }
-        
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        //let starRoll = 0
-
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)  > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 + CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
+            
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
             }
         }
-
-
-
+        
     }
     
     func didBegin(_ contact: SKPhysicsContact) {

--- a/Chapter 08/checkpoint - 8a/Pierre The Penguin/GameScene.swift
+++ b/Chapter 08/checkpoint - 8a/Pierre The Penguin/GameScene.swift
@@ -130,22 +130,22 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             encounterManager.placeNextEncounter(
                 currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
-        }
-        
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        //let starRoll = 0
-
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)  > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 + CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
+            
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
             }
         }
 

--- a/Chapter 08/checkpoint - 8b/Pierre The Penguin/GameScene.swift
+++ b/Chapter 08/checkpoint - 8b/Pierre The Penguin/GameScene.swift
@@ -145,23 +145,24 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             encounterManager.placeNextEncounter(
                 currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
-        }
-        
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        //let starRoll = 0
-
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)  > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 + CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
+            
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
             }
+            
         }
 
         // Position the backgrounds:

--- a/Chapter 09/checkpoint - 9a/Pierre The Penguin/GameScene.swift
+++ b/Chapter 09/checkpoint - 9a/Pierre The Penguin/GameScene.swift
@@ -151,22 +151,23 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             encounterManager.placeNextEncounter(
                 currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
-        }
-        
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        //let starRoll = 0
-
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)  > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 + CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
+            
+            
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
             }
         }
 

--- a/Chapter 09/checkpoint - 9a/Pierre The Penguin/Player.swift
+++ b/Chapter 09/checkpoint - 9a/Pierre The Penguin/Player.swift
@@ -153,16 +153,17 @@ class Player : SKSpriteNode, GameSprite {
         self.alpha = 1
         // Remove all animations:
         self.removeAllActions()
-        // Run the die animation:
-        self.run(self.dieAnimation)
         // Prevent any further upward movement:
         self.flapping = false
         // Stop forward movement:
         self.forwardVelocity = 0
         
-        // Alert the GameScene:
-        if let gameScene = self.parent as? GameScene {
-            gameScene.gameOver()
+        // Run the die animation:
+        self.run(self.dieAnimation) {
+            //Alert the GameScene:
+            if let gameScene = self.parent as? GameScene {
+                gameScene.gameOver()
+            }
         }
 
     }
@@ -308,7 +309,9 @@ class Player : SKSpriteNode, GameSprite {
             // Rotate the penguin on to his back:
             SKAction.rotate(toAngle: 3, duration: 1.5),
             SKAction.wait(forDuration: 0.5),
-            endDie
+            endDie,
+            // Allow time for penguin to fall to the ground with gravity
+            SKAction.wait(forDuration: 3.0)
             ])
 
 

--- a/Chapter 09/checkpoint - 9b/Pierre The Penguin/GameScene.swift
+++ b/Chapter 09/checkpoint - 9b/Pierre The Penguin/GameScene.swift
@@ -155,23 +155,24 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             encounterManager.placeNextEncounter(
                 currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
-        }
         
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        //let starRoll = 0
-
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)  > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 + CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
             }
+        
         }
 
         // Position the backgrounds:

--- a/Chapter 09/checkpoint - 9b/Pierre The Penguin/OptionsScene.swift
+++ b/Chapter 09/checkpoint - 9b/Pierre The Penguin/OptionsScene.swift
@@ -52,7 +52,7 @@ class OptionsScene: SKScene {
         
         //add slider base asset
         sliderBase.texture = textureAtlas.textureNamed("slider-base")
-        sliderBase.position = CGPoint(x: 50, y: 0)
+        sliderBase.position = CGPoint(x: 0, y: 0)
         sliderBase.size = CGSize(width: 200, height: 20)
         sliderBase.anchorPoint = CGPoint(x: 0, y: 0.5)
         self.addChild(sliderBase)

--- a/Chapter 09/checkpoint - 9b/Pierre The Penguin/Player.swift
+++ b/Chapter 09/checkpoint - 9b/Pierre The Penguin/Player.swift
@@ -161,18 +161,19 @@ class Player : SKSpriteNode, GameSprite {
         self.alpha = 1
         // Remove all animations:
         self.removeAllActions()
-        // Run the die animation:
-        self.run(self.dieAnimation)
         // Prevent any further upward movement:
         self.flapping = false
         // Stop forward movement:
         self.forwardVelocity = 0
         
-        // Alert the GameScene:
-        if let gameScene = self.parent as? GameScene {
-            gameScene.gameOver()
+        // Run the die animation:
+        self.run(self.dieAnimation) {
+            //Alert the GameScene:
+            if let gameScene = self.parent as? GameScene {
+                gameScene.gameOver()
+            }
         }
-
+        
     }
     
     func takeDamage() {
@@ -320,10 +321,12 @@ class Player : SKSpriteNode, GameSprite {
             // Rotate the penguin on to his back:
             SKAction.rotate(toAngle: 3, duration: 1.5),
             SKAction.wait(forDuration: 0.5),
-            endDie
+            endDie,
+            // Allow penguin to fall to the ground (gravity)
+            SKAction.wait(forDuration: 3.0)
             ])
 
-
+        
     }
     
 

--- a/Chapter 10/checkpoint - 10a/Pierre The Penguin/GameScene.swift
+++ b/Chapter 10/checkpoint - 10a/Pierre The Penguin/GameScene.swift
@@ -159,25 +159,26 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             encounterManager.placeNextEncounter(
                 currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
+        
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
+            }
+            
         }
         
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        //let starRoll = 0
-
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)  > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 + CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
-            }
-        }
-
         // Position the backgrounds:
         for background in self.backgrounds {
             background.updatePosition(playerProgress:

--- a/Chapter 10/checkpoint - 10a/Pierre The Penguin/OptionsScene.swift
+++ b/Chapter 10/checkpoint - 10a/Pierre The Penguin/OptionsScene.swift
@@ -52,7 +52,7 @@ class OptionsScene: SKScene {
         
         //add slider base asset
         sliderBase.texture = textureAtlas.textureNamed("slider-base")
-        sliderBase.position = CGPoint(x: 50, y: 0)
+        sliderBase.position = CGPoint(x: 0, y: 0)
         sliderBase.size = CGSize(width: 200, height: 20)
         sliderBase.anchorPoint = CGPoint(x: 0, y: 0.5)
         self.addChild(sliderBase)

--- a/Chapter 10/checkpoint - 10a/Pierre The Penguin/Player.swift
+++ b/Chapter 10/checkpoint - 10a/Pierre The Penguin/Player.swift
@@ -162,18 +162,19 @@ class Player : SKSpriteNode, GameSprite {
         self.alpha = 1
         // Remove all animations:
         self.removeAllActions()
-        // Run the die animation:
-        self.run(self.dieAnimation)
         // Prevent any further upward movement:
         self.flapping = false
         // Stop forward movement:
         self.forwardVelocity = 0
         
-        // Alert the GameScene:
-        if let gameScene = self.parent as? GameScene {
-            gameScene.gameOver()
+        // Run the die animation:
+        self.run(self.dieAnimation) {
+            //Alert the GameScene:
+            if let gameScene = self.parent as? GameScene {
+                gameScene.gameOver()
+            }
         }
-
+        
     }
     
     func takeDamage() {
@@ -321,7 +322,9 @@ class Player : SKSpriteNode, GameSprite {
             // Rotate the penguin on to his back:
             SKAction.rotate(toAngle: 3, duration: 1.5),
             SKAction.wait(forDuration: 0.5),
-            endDie
+            endDie,
+            // Allow penguin to fall to the ground (gravity)
+            SKAction.wait(forDuration: 3.0)
             ])
 
 

--- a/Chapter 10/checkpoint - 10b/Pierre The Penguin/GameScene.swift
+++ b/Chapter 10/checkpoint - 10b/Pierre The Penguin/GameScene.swift
@@ -164,35 +164,35 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         
         // Check to see if we should set a new encounter:
         if player.position.x > nextEncounterSpawnPosition {
-            encounterManager.placeNextEncounter(
-                currentXPos: nextEncounterSpawnPosition)
+            encounterManager.placeNextEncounter( currentXPos: nextEncounterSpawnPosition)
             nextEncounterSpawnPosition += 1200
-        }
-        
-        // Each encounter has a 10% chance to spawn a star:
-        let starRoll = Int(arc4random_uniform(10))
-        //let starRoll = 0
-
-        if starRoll == 0 {
-            // Only move the star if it is off the screen.
-            if abs(player.position.x - powerUpStar.position.x)  > 1200 {
-                // Y Position 50-450:
-                let randomYPos = 50 + CGFloat(arc4random_uniform(400))
-                powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
-                // Remove any previous velocity and spin:
-                powerUpStar.physicsBody?.angularVelocity = 0
-                powerUpStar.physicsBody?.velocity =
-                    CGVector(dx: 0, dy: 0)
+            
+            // Each encounter has a 10% chance to spawn a star:
+            let starRoll = Int(arc4random_uniform(10))
+            //let starRoll = 0
+            
+            if starRoll == 0 {
+                // Only move the star if it is off the screen.
+                if abs(player.position.x - powerUpStar.position.x)  > 1200 {
+                    // Y Position 50-450:
+                    let randomYPos = 50 + CGFloat(arc4random_uniform(400))
+                    powerUpStar.position = CGPoint(x: nextEncounterSpawnPosition, y: randomYPos)
+                    // Remove any previous velocity and spin:
+                    powerUpStar.physicsBody?.angularVelocity = 0
+                    powerUpStar.physicsBody?.velocity =
+                        CGVector(dx: 0, dy: 0)
+                }
             }
+            
+            if starRoll == 1 {
+                // Position the heart crate after this encounter:
+                heartCrate.reset()
+                heartCrate.position = CGPoint(x:
+                    nextEncounterSpawnPosition - 600, y: 270)
+            }
+            
         }
         
-        if starRoll == 1 {
-            // Position the heart crate after this encounter:
-            heartCrate.reset()
-            heartCrate.position = CGPoint(x:
-                nextEncounterSpawnPosition - 600, y: 270)
-        }
-
 
         // Position the backgrounds:
         for background in self.backgrounds {

--- a/Chapter 10/checkpoint - 10b/Pierre The Penguin/OptionsScene.swift
+++ b/Chapter 10/checkpoint - 10b/Pierre The Penguin/OptionsScene.swift
@@ -52,7 +52,7 @@ class OptionsScene: SKScene {
         
         //add slider base asset
         sliderBase.texture = textureAtlas.textureNamed("slider-base")
-        sliderBase.position = CGPoint(x: 50, y: 0)
+        sliderBase.position = CGPoint(x: 0, y: 0)
         sliderBase.size = CGSize(width: 200, height: 20)
         sliderBase.anchorPoint = CGPoint(x: 0, y: 0.5)
         self.addChild(sliderBase)

--- a/Chapter 10/checkpoint - 10b/Pierre The Penguin/Player.swift
+++ b/Chapter 10/checkpoint - 10b/Pierre The Penguin/Player.swift
@@ -163,18 +163,19 @@ class Player : SKSpriteNode, GameSprite {
         self.alpha = 1
         // Remove all animations:
         self.removeAllActions()
-        // Run the die animation:
-        self.run(self.dieAnimation)
         // Prevent any further upward movement:
         self.flapping = false
         // Stop forward movement:
         self.forwardVelocity = 0
         
-        // Alert the GameScene:
-        if let gameScene = self.parent as? GameScene {
-            gameScene.gameOver()
+        // Run the die animation:
+        self.run(self.dieAnimation) {
+            //Alert the GameScene:
+            if let gameScene = self.parent as? GameScene {
+                gameScene.gameOver()
+            }
         }
-
+        
     }
     
     func takeDamage() {
@@ -322,7 +323,9 @@ class Player : SKSpriteNode, GameSprite {
             // Rotate the penguin on to his back:
             SKAction.rotate(toAngle: 3, duration: 1.5),
             SKAction.wait(forDuration: 0.5),
-            endDie
+            endDie,
+            // Allow penguin to fall to the ground (gravity)
+            SKAction.wait(forDuration: 3.0)
             ])
 
 


### PR DESCRIPTION
**starRoll**
Fixed: The code relating to spawning a star, or a heart crate is now _ONLY_ run if we set a new encounter.  

Existing functionality:
EVERY time didSimulatephysics() fires code is run.  Hence, the 10% chance assumption is not functioning properly.


**Complete die() before HUD appears**
Fixed: When die() runs, allow the Penguin to fall to the ground (gravity) _BEFORE_ displaying the HUD.

Existing functionality:
The HUD appears prematurely at gameOver(), causing the die() animation of the Penguin to not be viewable in the foreground.


**sliderKnob**
Fixed: A visual placement issue that occurs to the sliderKnob location if the volume is set to 0.
The easy fix.. set sliderBase.position = CGPoint(x: 0, y: 0)

Exisiting functionality: 
If the volume is set at 0, it follows that the exisiting math will equal 0:
let pos = (Float)(sliderBase.position.x + sliderBase.frame.size.width) * volume

Hence, with the existing sliderBase.position = CGPoint(x: 50, y: 0) the sliderKnob will appear in the wrong place causing a visual UI bug.